### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/Ofl.Twitch.Abstractions/Ofl.Twitch.Abstractions.csproj
+++ b/src/Ofl.Twitch.Abstractions/Ofl.Twitch.Abstractions.csproj
@@ -8,7 +8,15 @@
     <RepositoryUrl>https://github.com/OneFrameLink/Ofl.Twitch.Abstractions.git</RepositoryUrl>
     <PackageTags>twitch twitch-api</PackageTags>
     <RootNamespace>Ofl.Twitch</RootNamespace>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
   </ItemGroup>

--- a/src/Ofl.Twitch.Extensions/Ofl.Twitch.Extensions.csproj
+++ b/src/Ofl.Twitch.Extensions/Ofl.Twitch.Extensions.csproj
@@ -9,7 +9,15 @@
     <RepositoryUrl>https://github.com/OneFrameLink/Ofl.Twitch.Extensions.git</RepositoryUrl>
     <PackageTags>twitch twitch-api</PackageTags>
     <RootNamespace>Ofl.Twitch</RootNamespace>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\Ofl.Twitch.Abstractions\Ofl.Twitch.Abstractions.csproj" />

--- a/src/Ofl.Twitch/Ofl.Twitch.csproj
+++ b/src/Ofl.Twitch/Ofl.Twitch.csproj
@@ -8,7 +8,15 @@
     <PackageProjectUrl>https://github.com/OneFrameLink/Ofl.Twitch</PackageProjectUrl>
     <RepositoryUrl>https://github.com/OneFrameLink/Ofl.Twitch.git</RepositoryUrl>
     <PackageTags>twitch twitch-api</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
